### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -10,6 +10,12 @@
         {
             var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
+            // Validate the Windows directory path
+            if (string.IsNullOrWhiteSpace(winDir) || !Path.IsPathRooted(winDir) || !Directory.Exists(winDir))
+            {
+                throw new InvalidOperationException("The Windows directory path is invalid.");
+            }
+
             var fonts = Path.Combine(winDir, "Fonts");
             var fontsFullPath = Path.GetFullPath(fonts);
 

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -11,10 +11,11 @@
             var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
             var fonts = Path.Combine(winDir, "Fonts");
+            var fontsFullPath = Path.GetFullPath(fonts);
 
-            if (Directory.Exists(fonts))
+            if (fontsFullPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(fontsFullPath))
             {
-                var files = Directory.GetFiles(fonts);
+                var files = Directory.GetFiles(fontsFullPath);
 
                 foreach (var file in files)
                 {
@@ -26,10 +27,11 @@
             }
 
             var psFonts = Path.Combine(winDir, "PSFonts");
+            var psFontsFullPath = Path.GetFullPath(psFonts);
 
-            if (Directory.Exists(psFonts))
+            if (psFontsFullPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(psFontsFullPath))
             {
-                var files = Directory.GetFiles(fonts);
+                var files = Directory.GetFiles(psFontsFullPath);
 
                 foreach (var file in files)
                 {

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -29,7 +29,9 @@
             var psFonts = Path.Combine(winDir, "PSFonts");
             var psFontsFullPath = Path.GetFullPath(psFonts);
 
-            if (psFontsFullPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(psFontsFullPath))
+            // Ensure the path is securely contained within the Windows directory
+            if (psFontsFullPath.StartsWith(Path.GetFullPath(winDir) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) 
+                && Directory.Exists(psFontsFullPath))
             {
                 var files = Directory.GetFiles(psFontsFullPath);
 


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/PdfPig/security/code-scanning/1](https://github.com/MjrTom/PdfPig/security/code-scanning/1)

To address the issue, we will validate the constructed paths (`fonts` and `psFonts`) to ensure they remain within the Windows directory. This can be achieved by resolving the absolute paths using `Path.GetFullPath` and verifying that they start with the expected Windows directory path. If the validation fails, the code will skip processing the directory.

Steps to fix:
1. Use `Path.GetFullPath` to resolve the absolute paths of `fonts` and `psFonts`.
2. Check that the resolved paths start with the `winDir` value followed by the directory separator.
3. If the validation fails, skip processing the directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
