### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -11,10 +11,11 @@
             var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
             var fonts = Path.Combine(winDir, "Fonts");
+            var resolvedFontsPath = Path.GetFullPath(fonts);
 
-            if (Directory.Exists(fonts))
+            if (resolvedFontsPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(resolvedFontsPath))
             {
-                var files = Directory.GetFiles(fonts);
+                var files = Directory.GetFiles(resolvedFontsPath);
 
                 foreach (var file in files)
                 {
@@ -26,10 +27,11 @@
             }
 
             var psFonts = Path.Combine(winDir, "PSFonts");
+            var resolvedPsFontsPath = Path.GetFullPath(psFonts);
 
-            if (Directory.Exists(psFonts))
+            if (resolvedPsFontsPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(resolvedPsFontsPath))
             {
-                var files = Directory.GetFiles(fonts);
+                var files = Directory.GetFiles(resolvedPsFontsPath);
 
                 foreach (var file in files)
                 {

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -6,6 +6,12 @@
 
     internal sealed class WindowsSystemFontLister : ISystemFontLister
     {
+        private static bool IsSubdirectory(string baseDir, string subDir)
+        {
+            var baseDirFullPath = Path.GetFullPath(baseDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            var subDirFullPath = Path.GetFullPath(subDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            return subDirFullPath.StartsWith(baseDirFullPath, StringComparison.OrdinalIgnoreCase);
+        }
         public IEnumerable<SystemFontRecord> GetAllFonts()
         {
             var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
@@ -13,7 +19,7 @@
             var fonts = Path.Combine(winDir, "Fonts");
             var resolvedFontsPath = Path.GetFullPath(fonts);
 
-            if (resolvedFontsPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(resolvedFontsPath))
+            if (IsSubdirectory(winDir, resolvedFontsPath) && Directory.Exists(resolvedFontsPath))
             {
                 var files = Directory.GetFiles(resolvedFontsPath);
 
@@ -29,7 +35,7 @@
             var psFonts = Path.Combine(winDir, "PSFonts");
             var resolvedPsFontsPath = Path.GetFullPath(psFonts);
 
-            if (resolvedPsFontsPath.StartsWith(winDir + Path.DirectorySeparatorChar) && Directory.Exists(resolvedPsFontsPath))
+            if (IsSubdirectory(winDir, resolvedPsFontsPath) && Directory.Exists(resolvedPsFontsPath))
             {
                 var files = Directory.GetFiles(resolvedPsFontsPath);
 


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/PdfPig/security/code-scanning/3](https://github.com/MjrTom/PdfPig/security/code-scanning/3)

To address the issue, we will validate the constructed paths (`fonts` and `psFonts`) to ensure they remain within the expected Windows directory. This can be achieved by resolving the absolute paths and verifying that they start with the expected `winDir` value. If the validation fails, the code will skip processing the directory.

Steps to fix:
1. Use `Path.GetFullPath` to resolve the absolute paths of `fonts` and `psFonts`.
2. Check that the resolved paths start with the `winDir` value, followed by a directory separator.
3. If the validation fails, skip processing the directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
