### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -29,7 +29,7 @@
             var psFonts = Path.Combine(winDir, "PSFonts");
             psFonts = Path.GetFullPath(psFonts);
 
-            if (psFonts.StartsWith(winDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) && Directory.Exists(psFonts))
+            if (psFonts.StartsWith(winDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) && Directory.Exists(psFonts))
             {
                 var files = Directory.GetFiles(psFonts);
 

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -29,7 +29,7 @@
             var psFonts = Path.Combine(winDir, "PSFonts");
             psFonts = Path.GetFullPath(psFonts);
 
-            if (psFonts.StartsWith(winDir, StringComparison.OrdinalIgnoreCase) && Directory.Exists(psFonts))
+            if (psFonts.StartsWith(winDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) && Directory.Exists(psFonts))
             {
                 var files = Directory.GetFiles(psFonts);
 

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/WindowsSystemFontLister.cs
@@ -11,8 +11,9 @@
             var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
             var fonts = Path.Combine(winDir, "Fonts");
+            fonts = Path.GetFullPath(fonts);
 
-            if (Directory.Exists(fonts))
+            if (fonts.StartsWith(winDir, StringComparison.OrdinalIgnoreCase) && Directory.Exists(fonts))
             {
                 var files = Directory.GetFiles(fonts);
 
@@ -26,10 +27,11 @@
             }
 
             var psFonts = Path.Combine(winDir, "PSFonts");
+            psFonts = Path.GetFullPath(psFonts);
 
-            if (Directory.Exists(psFonts))
+            if (psFonts.StartsWith(winDir, StringComparison.OrdinalIgnoreCase) && Directory.Exists(psFonts))
             {
-                var files = Directory.GetFiles(fonts);
+                var files = Directory.GetFiles(psFonts);
 
                 foreach (var file in files)
                 {


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/PdfPig/security/code-scanning/4](https://github.com/MjrTom/PdfPig/security/code-scanning/4)

To address the issue, we will validate the constructed paths (`fonts` and `psFonts`) to ensure they remain within the expected Windows directory. This can be achieved by resolving the absolute paths using `Path.GetFullPath` and verifying that they start with the expected Windows directory path (`winDir`). If the validation fails, the code will skip processing the directory.

Changes will be made to:
1. Validate the `fonts` and `psFonts` paths after they are constructed.
2. Ensure that the paths are only used if they are valid and within the expected directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
